### PR TITLE
Remove dependency on undefined model 'Account'

### DIFF
--- a/lib/omniauth/strategies/netforum_enterprise.rb
+++ b/lib/omniauth/strategies/netforum_enterprise.rb
@@ -59,7 +59,11 @@ module OmniAuth
       end
 
       def get_slug(event_code)
-        Account.find_by_event_code(event_code).slug
+        if defined? Account
+          return Account.find_by_event_code(event_code).slug
+        end
+
+        ''
       end
 
       def get_user_info(access_token)

--- a/lib/omniauth/strategies/netforum_enterprise.rb
+++ b/lib/omniauth/strategies/netforum_enterprise.rb
@@ -59,11 +59,9 @@ module OmniAuth
       end
 
       def get_slug(event_code)
-        if defined? Account
-          return Account.find_by_event_code(event_code).slug
-        end
+        return '' unless defined? Account
 
-        ''
+        Account.find_by_event_code(event_code).slug
       end
 
       def get_user_info(access_token)


### PR DESCRIPTION
There is code that references `Account`, but that model is not defined.  This
code change preserves the original functionality if that model is defined, but
allows broader use of the Gem with applications that do not have an `Account`.
